### PR TITLE
fix: CSP security error

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -3,23 +3,32 @@ const path = require('path')
 const serve = require('serve-static')
 
 module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
-  return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }), function renderSwaggerHtml (req, res) {
-    res.type('html').send(renderHtmlPage('Swagger UI', `
+  return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }),
+    function returnUiInit (req, res, next) {
+      if (req.path.endsWith('/swagger-ui-init.js')) {
+        res.type('.js')
+        res.send(`window.onload = function () {
+  window.ui = SwaggerUIBundle({
+    url: "${documentUrl}",
+    dom_id: '#swagger-ui'
+  })
+}
+        `)
+      } else {
+        next()
+      }
+    },
+    function renderSwaggerHtml (req, res) {
+      res.type('html').send(renderHtmlPage('Swagger UI', `
       <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
     `, `
       <div id="swagger-ui"></div>
       <script src="./swagger-ui-bundle.js"></script>
       <script src="./swagger-ui-standalone-preset.js"></script>
-      <script>
-        window.onload = function () {
-          window.ui = SwaggerUIBundle({
-            url: "${documentUrl}",
-            dom_id: '#swagger-ui'
-          })
-        }
-      </script>
+      <script src="./swagger-ui-init.js"></script>
     `))
-  }]
+    }
+  ]
 }
 
 function renderHtmlPage (title, head, body) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/express-openapi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Middleware for generating OpenAPI/Swagger documentation for your Express app",
   "author": "@unleash",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/express-openapi",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "Middleware for generating OpenAPI/Swagger documentation for your Express app",
   "author": "@unleash",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,19 @@ suite(name, function () {
       })
   })
 
+  test('serves onload function in swagger-ui-init.js file', function (done) {
+    const app = express()
+    app.use(openapi().swaggerui)
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}/swagger-ui-init.js`)
+      .end((err, res) => {
+        console.log(res.text)
+        assert(!err, err)
+        assert(res.text.includes('window.onload = function () {'))
+        done()
+      })
+  })
+
   test('load routes from the express app', function (done) {
     const app = express()
     const oapi = openapi()

--- a/test/index.js
+++ b/test/index.js
@@ -87,7 +87,6 @@ suite(name, function () {
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}/swagger-ui-init.js`)
       .end((err, res) => {
-        console.log(res.text)
         assert(!err, err)
         assert(res.text.includes('window.onload = function () {'))
         done()


### PR DESCRIPTION
[Content security policy (CSP)](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#1-restricting-inline-scripts) helps make our site more secure. Sites implementing CSP might encounter this issue when rendering Swagger UI: 
`Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' cdn.getunleash.io". Either the 'unsafe-inline' keyword, a hash ('sha256-f6ODck6GG+BFHrHDNsNQtQEHSyG3iP8zBIQEAqqyK/E='), or a nonce ('nonce-...') is required to enable inline execution.`

Moving the initialization script into a js file should fix this problem.